### PR TITLE
Lower Windows CMake requirement to 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (WIN32)
-    cmake_minimum_required(VERSION 3.22)
+    cmake_minimum_required(VERSION 3.21)
 else()
     cmake_minimum_required(VERSION 3.12)
 endif()


### PR DESCRIPTION
Visual Studio bundles CMake 3.21 and I have no idea
how to make it use system-wide CMake installation properly.
3.21 seems to work too anyway so just lower it.