### PR TITLE
Simplify logging headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
     OBJECT
     demangle.cpp
     demangle.h
+    formatters.cpp
     formatters.h
     itemlistupdater.h
     log.cpp

--- a/formatters.cpp
+++ b/formatters.cpp
@@ -1,0 +1,125 @@
+#include "formatters.h"
+
+#include <string_view>
+
+// If we don't include it here we will get undefined reference link error for fmt::formatter<fmt::string_view>
+#if FMT_VERSION >= 80000
+#include <fmt/format.h>
+#endif
+
+#include <QtGlobal>
+#include <QByteArray>
+#include <QLatin1String>
+#include <QStringView>
+
+#if QT_VERSION_MAJOR >= 6
+#include <QAnyStringView>
+#endif
+
+#ifdef Q_OS_WIN
+#include <guiddef.h>
+#include <winrt/base.h>
+#endif
+
+#include "demangle.h"
+
+namespace {
+    [[maybe_unused]]
+    fmt::string_view toFmtStringView(const QByteArray& str) {
+        return fmt::string_view(str.data(), static_cast<size_t>(str.size()));
+    }
+}
+
+auto fmt::formatter<QString>::format(const QString& string, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<string_view>::format(toFmtStringView(string.toUtf8()), ctx);
+}
+
+auto fmt::formatter<QStringView>::format(const QStringView& string, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<string_view>::format(toFmtStringView(string.toUtf8()), ctx);
+}
+
+auto fmt::formatter<QLatin1String>::format(const QLatin1String& string, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<string_view>::format(std::string_view(string.data(), static_cast<size_t>(string.size())), ctx);
+}
+
+auto fmt::formatter<QByteArray>::format(const QByteArray& array, fmt::format_context & ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<string_view>::format(toFmtStringView(array), ctx);
+}
+
+#if QT_VERSION_MAJOR >= 6
+
+auto fmt::formatter<QUtf8StringView>::format(const QUtf8StringView& string, format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<string_view>::format(string_view(string.data(), static_cast<size_t>(string.size())), ctx);
+}
+
+auto fmt::formatter<QAnyStringView>::format(const QAnyStringView& string, format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<QString>::format(string.toString(), ctx);
+}
+
+#endif
+
+namespace libtremotesf::impl {
+    template<typename Integer>
+    auto formatQEnumImpl(const QMetaEnum& meta, Integer value, fmt::format_context& ctx) -> decltype(ctx.out()) {
+        std::string unnamed{};
+        const char* key = [&]() -> const char* {
+            if (auto named = meta.valueToKey(static_cast<int>(value)); named) {
+                return named;
+            }
+            unnamed = fmt::format("<unnamed value {}>", value);
+            return unnamed.c_str();
+        }();
+        return fmt::format_to(ctx.out(), "{}::{}::{}", meta.scope(), meta.enumName(), key);
+    }
+
+    auto formatQEnum(const QMetaEnum& meta, int64_t value, fmt::format_context& ctx) -> decltype(ctx.out()) {
+        return formatQEnumImpl(meta, value, ctx);
+    }
+
+    auto formatQEnum(const QMetaEnum& meta, uint64_t value, fmt::format_context& ctx) -> decltype(ctx.out()) {
+        return formatQEnumImpl(meta, value, ctx);
+    }
+}
+
+namespace {
+    auto formatSystemError(std::string_view type, const std::system_error& e, fmt::format_context& ctx) -> decltype(ctx.out()) {
+        const int code = e.code().value();
+        return fmt::format_to(ctx.out(), "{}: {} (error code {} ({:#x}))", type, e.what(), code, static_cast<unsigned int>(code));
+    }
+}
+
+auto fmt::formatter<std::exception>::format(const std::exception& e, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    const auto type = libtremotesf::typeName(e);
+    const auto what = e.what();
+    if (auto s = dynamic_cast<const std::system_error*>(&e); s) {
+        return formatSystemError(type, *s, ctx);
+    }
+    return fmt::format_to(ctx.out(), "{}: {}", type, what);
+}
+
+auto fmt::formatter<std::system_error>::format(const std::system_error& e, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    return formatSystemError(libtremotesf::typeName(e), e, ctx);
+}
+
+#ifdef Q_OS_WIN
+
+auto fmt::formatter<winrt::hstring>::format(const winrt::hstring& str, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    return fmt::formatter<QString>::format(
+        QString::fromWCharArray(str.data(), static_cast<QString::size_type>(str.size())),
+        ctx
+    );
+}
+
+auto fmt::formatter<winrt::hresult_error>::format(const winrt::hresult_error& e, fmt::format_context& ctx) -> decltype(ctx.out()) {
+    const auto code = e.code().value;
+    return fmt::format_to(
+        ctx.out(),
+        "{}: {} (error code {} ({:#x}))",
+        libtremotesf::typeName(e),
+        e.message(),
+        code,
+        static_cast<uint32_t>(code)
+    );
+}
+
+#endif // Q_OS_WIN

--- a/itemlistupdater_test.cpp
+++ b/itemlistupdater_test.cpp
@@ -28,14 +28,9 @@ struct Item {
 };
 
 template<>
-struct fmt::formatter<Item> {
-    constexpr auto parse(fmt::format_parse_context& ctx) -> decltype(ctx.begin()) {
-        return ctx.begin();
-    }
-
-    template<typename FormatContext>
-    auto format(const Item& item, FormatContext& ctx) const -> decltype(ctx.out()) {
-        return fmt::format_to(ctx.out(), "Item(id={}, data={})", item.id, item.data);
+struct fmt::formatter<Item> : libtremotesf::SimpleFormatter {
+    auto format(const Item& item, format_context& ctx) const -> decltype(ctx.out()) {
+        return format_to(ctx.out(), "Item(id={}, data={})", item.id, item.data);
     }
 };
 

--- a/log_test.cpp
+++ b/log_test.cpp
@@ -4,6 +4,14 @@
 #include <QTest>
 #include <QVariant>
 
+#ifdef Q_OS_WIN
+#include <guiddef.h>
+#include <winrt/base.h>
+#endif
+
+#include <fmt/format.h>
+#include <fmt/compile.h>
+
 #include "log.h"
 #include "torrent.h"
 
@@ -24,7 +32,6 @@ private slots:
         printlnStdout("{}", "foo");
         printlnStdout(FMT_STRING("{}"), "foo");
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), "foo");
         printlnStdout(fmt::runtime("{}"), "foo");
 #endif
     }
@@ -35,7 +42,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -46,7 +52,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -57,7 +62,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -69,7 +73,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -80,7 +83,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -92,7 +94,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -103,7 +104,6 @@ private slots:
         printlnStdout("{}", str);
         printlnStdout(FMT_STRING("{}"), str);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), str);
         printlnStdout(fmt::runtime("{}"), str);
 #endif
     }
@@ -115,7 +115,6 @@ private slots:
         printlnStdout("{}", value);
         printlnStdout(FMT_STRING("{}"), value);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), value);
         printlnStdout(fmt::runtime("{}"), value);
 #endif
     }
@@ -126,7 +125,6 @@ private slots:
         printlnStdout("{}", list);
         printlnStdout(FMT_STRING("{}"), list);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), list);
         printlnStdout(fmt::runtime("{}"), list);
 #endif
     }
@@ -137,7 +135,6 @@ private slots:
         printlnStdout("{}", value);
         printlnStdout(FMT_STRING("{}"), value);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), value);
         printlnStdout(fmt::runtime("{}"), value);
 #endif
     }
@@ -147,7 +144,6 @@ private slots:
         printlnStdout("{}", *this);
         printlnStdout(FMT_STRING("{}"), *this);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), *this);
         printlnStdout(fmt::runtime("{}"), *this);
 #endif
     }
@@ -158,7 +154,6 @@ private slots:
         printlnStdout("{}", value);
         printlnStdout(FMT_STRING("{}"), value);
 #if FMT_VERSION >= 80000
-        printlnStdout(FMT_COMPILE("{}"), value);
         printlnStdout(fmt::runtime("{}"), value);
 #endif
     }
@@ -168,7 +163,6 @@ private slots:
         logInfo("foo");
         logInfo("{}", "foo");
         logInfo(FMT_STRING("{}"), "foo");
-        logInfo(FMT_COMPILE("{}"), "foo");
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), "foo");
 #endif
@@ -179,7 +173,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -190,7 +183,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -201,7 +193,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -213,7 +204,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -224,7 +214,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -236,7 +225,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -247,7 +235,6 @@ private slots:
         logInfo(str);
         logInfo("{}", str);
         logInfo(FMT_STRING("{}"), str);
-        logInfo(FMT_COMPILE("{}"), str);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), str);
 #endif
@@ -259,7 +246,6 @@ private slots:
         logInfo(value);
         logInfo("{}", value);
         logInfo(FMT_STRING("{}"), value);
-        logInfo(FMT_COMPILE("{}"), value);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), value);
 #endif
@@ -270,7 +256,6 @@ private slots:
         logInfo(list);
         logInfo("{}", list);
         logInfo(FMT_STRING("{}"), list);
-        logInfo(FMT_COMPILE("{}"), list);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), list);
 #endif
@@ -281,7 +266,6 @@ private slots:
         logInfo(value);
         logInfo("{}", value);
         logInfo(FMT_STRING("{}"), value);
-        logInfo(FMT_COMPILE("{}"), value);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), value);
 #endif
@@ -291,7 +275,6 @@ private slots:
         logInfo(*this);
         logInfo("{}", *this);
         logInfo(FMT_STRING("{}"), *this);
-        logInfo(FMT_COMPILE("{}"), *this);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), *this);
 #endif
@@ -302,7 +285,6 @@ private slots:
         logInfo(value);
         logInfo("{}", value);
         logInfo(FMT_STRING("{}"), value);
-        logInfo(FMT_COMPILE("{}"), value);
 #if FMT_VERSION >= 80000
         logInfo(fmt::runtime("{}"), value);
 #endif

--- a/torrent.cpp
+++ b/torrent.cpp
@@ -848,3 +848,7 @@ namespace libtremotesf
         mData.singleFile = (torrentMap.value(prioritiesKey).toArray().size() == 1);
     }
 }
+
+auto fmt::formatter<libtremotesf::Torrent>::format(const libtremotesf::Torrent& torrent, format_context& ctx) -> decltype(ctx.out()) {
+    return format_to(ctx.out(), "Torrent(id={}, name={})", torrent.id(), torrent.name());
+}

--- a/torrent.h
+++ b/torrent.h
@@ -24,8 +24,7 @@
 #include <QDateTime>
 #include <QObject>
 
-#include <fmt/core.h>
-
+#include "formatters.h"
 #include "peer.h"
 #include "torrentfile.h"
 #include "tracker.h"
@@ -280,15 +279,8 @@ namespace libtremotesf
 // SWIG can't parse it :(
 #ifndef SWIG
 template<>
-struct fmt::formatter<libtremotesf::Torrent> {
-    constexpr auto parse(fmt::format_parse_context& ctx) -> decltype(ctx.begin()) {
-        return ctx.begin();
-    }
-
-    template<typename FormatContext>
-    auto format(const libtremotesf::Torrent& torrent, FormatContext& ctx) -> decltype(ctx.out()) {
-        return fmt::format_to(ctx.out(), "Torrent(id={}, name={})", torrent.id(), torrent.name());
-    }
+struct fmt::formatter<libtremotesf::Torrent> : libtremotesf::SimpleFormatter {
+    auto format(const libtremotesf::Torrent& torrent, format_context& ctx) -> decltype(ctx.out());
 };
 #endif // SWIG
 


### PR DESCRIPTION
1. Move implementations of custom formatters to cpp file.
2. Don't include <fmt/format.h> in headers

As a consequence, we can no longer use FMT_COMPILE and fmt::to_string with our formatters.