### PR TITLE
Convert paths to use / separators when server is running on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ add_library(
     literals.h
     log.cpp
     log.h
+    pathutils.cpp
+    pathutils.h
     peer.cpp
     peer.h
     rpc.cpp

--- a/log_test.cpp
+++ b/log_test.cpp
@@ -134,7 +134,7 @@ private slots:
     }
 
     void stdoutTorrent() {
-        const Torrent value(0, {}, nullptr);
+        const Torrent value{};
         printlnStdout(value);
         printlnStdout("{}", value);
         printlnStdout(FMT_STRING("{}"), value);
@@ -265,7 +265,7 @@ private slots:
     }
 
     void infoTorrent() {
-        const Torrent value(0, {}, nullptr);
+        const Torrent value{};
         logInfo(value);
         logInfo("{}", value);
         logInfo(FMT_STRING("{}"), value);

--- a/pathutils.cpp
+++ b/pathutils.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2015-2022 Alexey Rochev
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pathutils.h"
+#include "rpc.h"
+
+namespace libtremotesf {
+    namespace {
+        QString fromNativeRemoteSeparators(const QString& path, const Rpc* rpc) {
+            if (!rpc->isServerRunningOnWindows()) return path;
+            QString internal = path;
+            internal.replace('\\', '/');
+            return internal;
+        }
+    }
+
+    QString normalizeRemotePath(const QString& path, const Rpc* rpc) {
+        // In case of Windows, Transmission may return paths with both \ and / separators over RPC
+        // Normalize them to /
+        auto normalized = fromNativeRemoteSeparators(path, rpc);
+        if (normalized.endsWith('/')) {
+            normalized.chop(1);
+        }
+        return normalized;
+    }
+
+    QString toNativeRemoteSeparators(const QString& path, const Rpc* rpc) {
+        if (!rpc->isServerRunningOnWindows()) return path;
+        QString native = path;
+        native.replace('/', '\\');
+        return native;
+    }
+}

--- a/pathutils.h
+++ b/pathutils.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2015-2022 Alexey Rochev
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef TREMOTESF_RPC_PATHUTILS_H
+#define TREMOTESF_RPC_PATHUTILS_H
+
+#include <QString>
+
+namespace libtremotesf {
+    class Rpc;
+
+    QString normalizeRemotePath(const QString& path, const Rpc* rpc);
+    QString toNativeRemoteSeparators(const QString& path, const Rpc* rpc);
+}
+
+namespace tremotesf {
+    using libtremotesf::normalizeRemotePath;
+    using libtremotesf::toNativeRemoteSeparators;
+}
+
+#endif // TREMOTESF_RPC_PATHUTILS_H

--- a/serversettings.cpp
+++ b/serversettings.cpp
@@ -8,6 +8,7 @@
 #include <QRegularExpression>
 
 #include "literals.h"
+#include "pathutils.h"
 #include "rpc.h"
 #include "stdutils.h"
 
@@ -123,7 +124,7 @@ namespace libtremotesf {
 
     void ServerSettings::setDownloadDirectory(const QString& directory) {
         if (directory != mData.downloadDirectory) {
-            mData.downloadDirectory = directory;
+            mData.downloadDirectory = normalizeRemotePath(directory, mRpc);
             if (mSaveOnSet) {
                 mRpc->setSessionProperty(downloadDirectoryKey, mData.downloadDirectory);
             }
@@ -170,7 +171,7 @@ namespace libtremotesf {
 
     void ServerSettings::setIncompleteDirectory(const QString& directory) {
         if (directory != mData.incompleteDirectory) {
-            mData.incompleteDirectory = directory;
+            mData.incompleteDirectory = normalizeRemotePath(directory, mRpc);
             if (mSaveOnSet) {
                 mRpc->setSessionProperty(incompleteDirectoryKey, mData.incompleteDirectory);
             }
@@ -475,9 +476,13 @@ namespace libtremotesf {
 
         mData.rpcVersion = serverSettings.value("rpc-version"_l1).toInt();
         mData.minimumRpcVersion = serverSettings.value("rpc-version-minimum"_l1).toInt();
-        mData.configDirectory = serverSettings.value(configDirKey).toString();
+        mData.configDirectory = normalizeRemotePath(serverSettings.value(configDirKey).toString(), mRpc);
 
-        setChanged(mData.downloadDirectory, serverSettings.value(downloadDirectoryKey).toString(), changed);
+        setChanged(
+            mData.downloadDirectory,
+            normalizeRemotePath(serverSettings.value(downloadDirectoryKey).toString(), mRpc),
+            changed
+        );
         setChanged(mData.trashTorrentFiles, serverSettings.value(trashTorrentFilesKey).toBool(), changed);
         setChanged(mData.startAddedTorrents, serverSettings.value(startAddedTorrentsKey).toBool(), changed);
         setChanged(mData.renameIncompleteFiles, serverSettings.value(renameIncompleteFilesKey).toBool(), changed);
@@ -486,7 +491,7 @@ namespace libtremotesf {
             serverSettings.value(incompleteDirectoryEnabledKey).toBool(),
             changed
         );
-        setChanged(mData.incompleteDirectory, serverSettings.value(incompleteDirectoryKey).toString(), changed);
+        setChanged(mData.incompleteDirectory, normalizeRemotePath(serverSettings.value(incompleteDirectoryKey).toString(), mRpc), changed);
 
         setChanged(mData.ratioLimited, serverSettings.value(ratioLimitedKey).toBool(), changed);
         setChanged(mData.ratioLimit, serverSettings.value(ratioLimitKey).toDouble(), changed);

--- a/torrent.h
+++ b/torrent.h
@@ -47,7 +47,7 @@ namespace libtremotesf {
         enum IdleSeedingLimitMode { GlobalIdleSeedingLimit, SingleIdleSeedingLimit, UnlimitedIdleSeeding };
         Q_ENUM(IdleSeedingLimitMode)
 
-        bool update(const QJsonObject& torrentMap);
+        bool update(const QJsonObject& torrentMap, const Rpc* rpc);
 
         int id = 0;
         QString hashString;
@@ -125,6 +125,8 @@ namespace libtremotesf {
         static constexpr auto idKey = "id"_l1;
 
         explicit Torrent(int id, const QJsonObject& torrentMap, Rpc* rpc, QObject* parent = nullptr);
+        // For testing only
+        explicit Torrent() = default;
 
         int id() const;
         const QString& hashString() const;


### PR DESCRIPTION
Transmission is inconsistent about paths that it returns over RPC. They may use both \ and / separators.
Convert them to always use / separators internally, to match Qt convention.

Also add toNativeRemoteSeparators() to display paths using \ separators in UI.