### PR TITLE
Rework how we track pending requests

### DIFF
--- a/requestrouter_test.cpp
+++ b/requestrouter_test.cpp
@@ -152,7 +152,7 @@ namespace {
 
         void checkUrlIsCorrect() {
             mServer.handle([&](const httplib::Request&, httplib::Response& res) { success(res); });
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->arguments, QJsonObject{});
             QCOMPARE(response->success, true);
@@ -173,7 +173,7 @@ namespace {
                 }
             });
 
-            const auto response = waitForResponse(method, arguments);
+            const auto response = waitForResponse(method, arguments, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->success, true);
         }
@@ -188,7 +188,7 @@ namespace {
                 mRouter.setConfiguration(std::move(config));
             }
 
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::TimedOut);
             logInfo("Returning");
@@ -200,7 +200,7 @@ namespace {
                 config.serverUrl.setPort(9);
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -216,7 +216,7 @@ namespace {
                 config.serverUrl.setPort(tcpServer.serverPort());
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -233,7 +233,7 @@ namespace {
                 config.retryAttempts = retryAttempts;
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
             QCOMPARE(requestsCount.load(), retryAttempts + 1);
@@ -251,7 +251,7 @@ namespace {
                 config.serverUrl.setPort(server.port);
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -270,7 +270,7 @@ namespace {
                     QSslCertificate::fromPath(TEST_DATA_PATH "/root-certificate.pem", QSsl::Pem);
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->success, true);
         }
@@ -288,7 +288,7 @@ namespace {
                 config.serverCertificateChain = QSslCertificate::fromPath(TEST_DATA_PATH "/chain.pem", QSsl::Pem);
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->success, true);
         }
@@ -308,7 +308,7 @@ namespace {
                     QSslCertificate::fromPath(TEST_DATA_PATH "/root-certificate.pem", QSsl::Pem);
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -335,7 +335,7 @@ namespace {
                 }
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->success, true);
         }
@@ -344,14 +344,14 @@ namespace {
             mServer.handle([&](const httplib::Request&, httplib::Response& res) {
                 res.set_content(invalidJsonResponse, contentType);
             });
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ParseError);
         }
 
         void checkConflictErrorWithoutSessionIdIsHandled() {
             mServer.handle([&](const httplib::Request&, httplib::Response& res) { res.status = 409; });
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -362,7 +362,7 @@ namespace {
                 res.status = 409;
                 res.set_header(sessionIdHeader, sessionIdValue);
             });
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::ConnectionError);
         }
@@ -377,7 +377,7 @@ namespace {
                 }
                 res.set_header(sessionIdHeader, sessionIdValue);
             });
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->arguments, QJsonObject{});
             QCOMPARE(response->success, true);
@@ -393,13 +393,13 @@ namespace {
                 }
                 res.set_header(sessionIdHeader, sessionIdValue);
             });
-            auto response = waitForResponse("foo"_l1, QByteArray{});
+            auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->arguments, QJsonObject{});
             QCOMPARE(response->success, true);
 
             sessionIdValue = "session id 2";
-            response = waitForResponse("foo"_l1, QByteArray{});
+            response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->arguments, QJsonObject{});
             QCOMPARE(response->success, true);
@@ -419,7 +419,7 @@ namespace {
                 config.password = password;
                 mRouter.setConfiguration(std::move(config));
             }
-            const auto response = waitForResponse("foo"_l1, QByteArray{});
+            const auto response = waitForResponse("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(response.has_value(), true);
             QCOMPARE(response->arguments, QJsonObject{});
             QCOMPARE(response->success, true);
@@ -429,9 +429,74 @@ namespace {
             mServer.handle([&](const httplib::Request& req, httplib::Response& res) {
                 checkAuthentication(req, res, "foo", "bar");
             });
-            const auto error = waitForError("foo"_l1, QByteArray{});
+            const auto error = waitForError("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent);
             QCOMPARE(error.has_value(), true);
             QCOMPARE(error.value(), RpcError::AuthenticationError);
+        }
+
+        void checkIndependentRequest() {
+            mServer.handle([&](const httplib::Request&, httplib::Response& res) { success(res); });
+
+            std::optional<RequestRouter::Response> response{};
+            mRouter.postRequest("foo"_l1, QByteArray{}, RequestRouter::RequestType::Independent, [&](auto r) {
+                response = std::move(r);
+            });
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), false);
+
+            const bool ok = QTest::qWaitFor([&] { return response.has_value(); });
+            if (!ok) {
+                QWARN("Timed out when waiting for response");
+            }
+
+            QCOMPARE(response.has_value(), true);
+            QCOMPARE(response->arguments, QJsonObject{});
+            QCOMPARE(response->success, true);
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), false);
+        }
+
+        void checkDataUpdateRequest() {
+            mServer.handle([&](const httplib::Request&, httplib::Response& res) { success(res); });
+
+            std::optional<RequestRouter::Response> response{};
+            mRouter.postRequest("foo"_l1, QByteArray{}, RequestRouter::RequestType::DataUpdate, [&](auto r) {
+                response = std::move(r);
+            });
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), true);
+
+            const bool ok = QTest::qWaitFor([&] { return response.has_value(); });
+            if (!ok) {
+                QWARN("Timed out when waiting for response");
+            }
+
+            QCOMPARE(response.has_value(), true);
+            QCOMPARE(response->arguments, QJsonObject{});
+            QCOMPARE(response->success, true);
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), false);
+        }
+
+        void checkDataUpdateRequestCancellation() {
+            mServer.handle([&](const httplib::Request&, httplib::Response& res) { success(res); });
+
+            mRouter.postRequest("foo"_l1, QByteArray{}, RequestRouter::RequestType::DataUpdate, [&](auto) {});
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), true);
+            mRouter.cancelPendingRequestsAndClearSessionId();
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), false);
+        }
+
+        void checkMultipleDataUpdateRequestsCancellation() {
+            mServer.handle([&](const httplib::Request&, httplib::Response& res) { success(res); });
+
+            mRouter.postRequest("foo"_l1, QByteArray{}, RequestRouter::RequestType::DataUpdate, [&](auto) {});
+            mRouter.postRequest("foo"_l1, QByteArray{}, RequestRouter::RequestType::DataUpdate, [&](auto) {});
+
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), true);
+            mRouter.cancelPendingRequestsAndClearSessionId();
+            QCOMPARE(mRouter.hasPendingDataUpdateRequests(), false);
         }
 
     private:

--- a/rpc.h
+++ b/rpc.h
@@ -167,15 +167,15 @@ namespace libtremotesf {
         void
         setTorrentProperty(int id, const QString& property, const QJsonValue& value, bool updateIfSuccessful = false);
         void setTorrentsLocation(const std::vector<int>& ids, const QString& location, bool moveFiles);
-        void getTorrentsFiles(const std::vector<int>& ids, bool scheduled);
-        void getTorrentsPeers(const std::vector<int>& ids, bool scheduled);
+        void getTorrentsFiles(const std::vector<int>& ids, bool asDataUpdate);
+        void getTorrentsPeers(const std::vector<int>& ids, bool asDataUpdate);
 
         void renameTorrentFile(int torrentId, const QString& filePath, const QString& newName);
 
         void getDownloadDirFreeSpace();
         void getFreeSpaceForPath(const QString& path);
 
-        void updateData(bool updateServerSettings = true);
+        void updateData();
 
         void shutdownServer();
 
@@ -189,7 +189,6 @@ namespace libtremotesf {
         void checkTorrentsSingleFile(const std::vector<int>& torrentIds);
         void getServerStats();
 
-        void maybeFinishUpdatingTorrents();
         bool checkIfUpdateCompleted();
         bool checkIfConnectionCompleted();
         void maybeFinishUpdateOrConnection();
@@ -207,9 +206,6 @@ namespace libtremotesf {
         std::optional<bool> mServerIsLocal{};
         std::optional<int> mPendingHostInfoLookupId{};
 
-        bool mServerSettingsUpdated{};
-        bool mTorrentsUpdated{};
-        bool mServerStatsUpdated{};
         QTimer* mUpdateTimer{};
         QTimer* mAutoReconnectTimer{};
 

--- a/torrent.cpp
+++ b/torrent.cpp
@@ -710,34 +710,7 @@ namespace libtremotesf {
 
     const std::vector<Peer>& Torrent::peers() const { return mPeers; }
 
-    bool Torrent::isUpdated() const {
-        bool updated = true;
-        if (mFilesEnabled && !mFilesUpdated) {
-            updated = false;
-        }
-        if (mPeersEnabled && !mPeersUpdated) {
-            updated = false;
-        }
-        return updated;
-    }
-
-    void Torrent::checkThatFilesUpdated() {
-        if (mFilesEnabled && !mFilesUpdated) {
-            logWarning("Files were not updated for {}", *this);
-            mFilesUpdated = true;
-        }
-    }
-
-    void Torrent::checkThatPeersUpdated() {
-        if (mPeersEnabled && !mPeersUpdated) {
-            logWarning("Peers were not updated for {}", *this);
-            mPeersUpdated = true;
-        }
-    }
-
     bool Torrent::update(const QJsonObject& object) {
-        mFilesUpdated = false;
-        mPeersUpdated = false;
         const bool c = mData.update(object, false);
         emit updated();
         if (c) {
@@ -747,8 +720,6 @@ namespace libtremotesf {
     }
 
     bool Torrent::update(const std::vector<std::optional<TorrentData::UpdateKey>>& keys, const QJsonArray& values) {
-        mFilesUpdated = false;
-        mPeersUpdated = false;
         const bool c = mData.update(keys, values, false);
         emit updated();
         if (c) {
@@ -779,8 +750,6 @@ namespace libtremotesf {
                 }
             }
         }
-
-        mFilesUpdated = true;
 
         emit filesUpdated(changed);
         emit mRpc->torrentFilesUpdated(this, changed);
@@ -845,8 +814,6 @@ namespace libtremotesf {
 
         PeersListUpdater updater;
         updater.update(mPeers, std::move(newPeers));
-
-        mPeersUpdated = true;
 
         emit peersUpdated(updater.removedIndexRanges, updater.changedIndexRanges, updater.addedCount);
         emit mRpc

--- a/torrent.h
+++ b/torrent.h
@@ -234,10 +234,6 @@ namespace libtremotesf {
         void setPeersEnabled(bool enabled);
         const std::vector<Peer>& peers() const;
 
-        bool isUpdated() const;
-        void checkThatFilesUpdated();
-        void checkThatPeersUpdated();
-
         [[nodiscard]] bool update(const QJsonObject& object);
         [[nodiscard]] bool
         update(const std::vector<std::optional<TorrentData::UpdateKey>>& keys, const QJsonArray& values);
@@ -247,18 +243,15 @@ namespace libtremotesf {
         void checkSingleFile(const QJsonObject& torrentMap);
 
     private:
-        Rpc* mRpc;
+        Rpc* mRpc{};
 
-        TorrentData mData;
+        TorrentData mData{};
 
-        std::vector<TorrentFile> mFiles;
-        bool mFilesEnabled = false;
-        bool mFilesUpdated = false;
+        std::vector<TorrentFile> mFiles{};
+        bool mFilesEnabled{};
 
-        std::vector<Peer> mPeers;
-        bool mPeersEnabled = false;
-        bool mPeersUpdated = false;
-
+        std::vector<Peer> mPeers{};
+        bool mPeersEnabled{};
     signals:
         void updated();
         void changed();


### PR DESCRIPTION
Attach metadata to pending requests in RequestRouter instead of maintaing boolean fields separately.