### PR TITLE
Replace long long with qint64

### DIFF
--- a/jsonutils.h
+++ b/jsonutils.h
@@ -81,8 +81,16 @@ namespace libtremotesf::impl {
         return array;
     }
 
+    inline qint64 toInt64(const QJsonValue& value) {
+#if QT_VERSION_MAJOR > 5
+        return value.toInteger();
+#else
+        return static_cast<qint64>(value.toDouble());
+#endif
+    }
+
     inline void updateDateTime(QDateTime& dateTime, const QJsonValue& value, bool& changed) {
-        const auto newDateTime = static_cast<qint64>(value.toDouble());
+        const auto newDateTime = toInt64(value);
         if (newDateTime > 0) {
             if (!dateTime.isValid() || newDateTime != dateTime.toSecsSinceEpoch()) {
                 dateTime.setSecsSinceEpoch(newDateTime);

--- a/peer.cpp
+++ b/peer.cpp
@@ -6,10 +6,13 @@
 
 #include <QJsonObject>
 
+#include "jsonutils.h"
 #include "literals.h"
 #include "stdutils.h"
 
 namespace libtremotesf {
+    using namespace impl;
+
     Peer::Peer(QString&& address, const QJsonObject& peerJson)
         : address(std::move(address)), client(peerJson.value("clientName"_l1).toString()) {
         update(peerJson);
@@ -17,8 +20,8 @@ namespace libtremotesf {
 
     bool Peer::update(const QJsonObject& peerJson) {
         bool changed = false;
-        setChanged(downloadSpeed, static_cast<long long>(peerJson.value("rateToClient"_l1).toDouble()), changed);
-        setChanged(uploadSpeed, static_cast<long long>(peerJson.value("rateToPeer"_l1).toDouble()), changed);
+        setChanged(downloadSpeed, toInt64(peerJson.value("rateToClient"_l1)), changed);
+        setChanged(uploadSpeed, toInt64(peerJson.value("rateToPeer"_l1)), changed);
         setChanged(progress, peerJson.value("progress"_l1).toDouble(), changed);
         setChanged(flags, peerJson.value("flagStr"_l1).toString(), changed);
         return changed;

--- a/peer.h
+++ b/peer.h
@@ -23,8 +23,8 @@ namespace libtremotesf {
 
         QString address{};
         QString client{};
-        long long downloadSpeed{};
-        long long uploadSpeed{};
+        qint64 downloadSpeed{};
+        qint64 uploadSpeed{};
         double progress{};
         QString flags{};
     };

--- a/rpc.cpp
+++ b/rpc.cpp
@@ -31,6 +31,8 @@ SPECIALIZE_FORMATTER_FOR_QDEBUG(QHostAddress)
 SPECIALIZE_FORMATTER_FOR_QDEBUG(QUrl)
 
 namespace libtremotesf {
+    using namespace impl;
+
     namespace {
         // Transmission 2.40+
         constexpr int minimumRpcVersion = 14;
@@ -680,9 +682,7 @@ namespace libtremotesf {
                 RequestRouter::RequestType::Independent,
                 [=](const RequestRouter::Response& response) {
                     if (response.success) {
-                        emit gotDownloadDirFreeSpace(
-                            static_cast<long long>(response.arguments.value("download-dir-free-space"_l1).toDouble())
-                        );
+                        emit gotDownloadDirFreeSpace(toInt64(response.arguments.value("download-dir-free-space"_l1)));
                     }
                 }
             );
@@ -699,8 +699,7 @@ namespace libtremotesf {
                     emit gotFreeSpaceForPath(
                         path,
                         response.success,
-                        response.success ? static_cast<long long>(response.arguments.value("size-bytes"_l1).toDouble())
-                                         : 0
+                        response.success ? toInt64(response.arguments.value("size-bytes"_l1)) : 0
                     );
                 }
             );

--- a/rpc.h
+++ b/rpc.h
@@ -264,8 +264,8 @@ namespace libtremotesf {
         void torrentAddDuplicate();
         void torrentAddError();
 
-        void gotDownloadDirFreeSpace(long long bytes);
-        void gotFreeSpaceForPath(const QString& path, bool success, long long bytes);
+        void gotDownloadDirFreeSpace(qint64 bytes);
+        void gotFreeSpaceForPath(const QString& path, bool success, qint64 bytes);
 
         void updateDisabledChanged();
     };

--- a/serverstats.cpp
+++ b/serverstats.cpp
@@ -6,38 +6,22 @@
 
 #include <QJsonObject>
 
+#include "jsonutils.h"
 #include "literals.h"
 
 namespace libtremotesf {
-    long long SessionStats::downloaded() const { return mDownloaded; }
-
-    long long SessionStats::uploaded() const { return mUploaded; }
-
-    int SessionStats::duration() const { return mDuration; }
-
-    int SessionStats::sessionCount() const { return mSessionCount; }
+    using namespace impl;
 
     void SessionStats::update(const QJsonObject& stats) {
-        mDownloaded = static_cast<long long>(stats.value("downloadedBytes"_l1).toDouble());
-        mUploaded = static_cast<long long>(stats.value("uploadedBytes"_l1).toDouble());
+        mDownloaded = toInt64(stats.value("downloadedBytes"_l1));
+        mUploaded = toInt64(stats.value("uploadedBytes"_l1));
         mDuration = stats.value("secondsActive"_l1).toInt();
         mSessionCount = stats.value("sessionCount"_l1).toInt();
     }
 
-    ServerStats::ServerStats(QObject* parent)
-        : QObject(parent), mDownloadSpeed(0), mUploadSpeed(0), mCurrentSession(), mTotal() {}
-
-    long long ServerStats::downloadSpeed() const { return mDownloadSpeed; }
-
-    long long ServerStats::uploadSpeed() const { return mUploadSpeed; }
-
-    SessionStats ServerStats::currentSession() const { return mCurrentSession; }
-
-    SessionStats ServerStats::total() const { return mTotal; }
-
     void ServerStats::update(const QJsonObject& serverStats) {
-        mDownloadSpeed = static_cast<long long>(serverStats.value("downloadSpeed"_l1).toDouble());
-        mUploadSpeed = static_cast<long long>(serverStats.value("uploadSpeed"_l1).toDouble());
+        mDownloadSpeed = toInt64(serverStats.value("downloadSpeed"_l1));
+        mUploadSpeed = toInt64(serverStats.value("uploadSpeed"_l1));
         mCurrentSession.update(serverStats.value("current-stats"_l1).toObject());
         mTotal.update(serverStats.value("cumulative-stats"_l1).toObject());
         emit updated();

--- a/serverstats.h
+++ b/serverstats.h
@@ -14,38 +14,38 @@ namespace libtremotesf {
 
     class SessionStats {
     public:
-        long long downloaded() const;
-        long long uploaded() const;
-        int duration() const;
-        int sessionCount() const;
+        [[nodiscard]] qint64 downloaded() const { return mDownloaded; };
+        [[nodiscard]] qint64 uploaded() const { return mUploaded; };
+        [[nodiscard]] int duration() const { return mDuration; };
+        [[nodiscard]] int sessionCount() const { return mSessionCount; };
 
         void update(const QJsonObject& stats);
 
     private:
-        long long mDownloaded;
-        long long mUploaded;
-        int mDuration;
-        int mSessionCount;
+        qint64 mDownloaded{};
+        qint64 mUploaded{};
+        int mDuration{};
+        int mSessionCount{};
     };
 
     class ServerStats : public QObject {
         Q_OBJECT
     public:
-        explicit ServerStats(QObject* parent = nullptr);
+        using QObject::QObject;
 
-        long long downloadSpeed() const;
-        long long uploadSpeed() const;
+        [[nodiscard]] qint64 downloadSpeed() const { return mDownloadSpeed; };
+        [[nodiscard]] qint64 uploadSpeed() const { return mUploadSpeed; };
 
-        SessionStats currentSession() const;
-        SessionStats total() const;
+        [[nodiscard]] SessionStats currentSession() const { return mCurrentSession; };
+        [[nodiscard]] SessionStats total() const { return mTotal; };
 
         void update(const QJsonObject& serverStats);
 
     private:
-        long long mDownloadSpeed;
-        long long mUploadSpeed;
-        SessionStats mCurrentSession;
-        SessionStats mTotal;
+        qint64 mDownloadSpeed{};
+        qint64 mUploadSpeed{};
+        SessionStats mCurrentSession{};
+        SessionStats mTotal{};
     signals:
         void updated();
     };

--- a/torrent.cpp
+++ b/torrent.cpp
@@ -275,13 +275,13 @@ namespace libtremotesf {
         case TorrentData::UpdateKey::QueuePosition:
             return setChanged(queuePosition, value.toInt(), changed);
         case TorrentData::UpdateKey::TotalSize:
-            return setChanged(totalSize, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(totalSize, toInt64(value), changed);
         case TorrentData::UpdateKey::CompletedSize:
-            return setChanged(completedSize, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(completedSize, toInt64(value), changed);
         case TorrentData::UpdateKey::LeftUntilDone:
-            return setChanged(leftUntilDone, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(leftUntilDone, toInt64(value), changed);
         case TorrentData::UpdateKey::SizeWhenDone:
-            return setChanged(sizeWhenDone, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(sizeWhenDone, toInt64(value), changed);
         case TorrentData::UpdateKey::PercentDone:
             return setChanged(percentDone, value.toDouble(), changed);
         case TorrentData::UpdateKey::RecheckProgress:
@@ -291,9 +291,9 @@ namespace libtremotesf {
         case TorrentData::UpdateKey::MetadataPercentComplete:
             return setChanged(metadataComplete, value.toInt() == 1, changed);
         case TorrentData::UpdateKey::DownloadSpeed:
-            return setChanged(downloadSpeed, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(downloadSpeed, toInt64(value), changed);
         case TorrentData::UpdateKey::UploadSpeed:
-            return setChanged(uploadSpeed, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(uploadSpeed, toInt64(value), changed);
         case TorrentData::UpdateKey::DownloadSpeedLimited:
             return setChanged(downloadSpeedLimited, value.toBool(), changed);
         case TorrentData::UpdateKey::DownloadSpeedLimit:
@@ -303,9 +303,9 @@ namespace libtremotesf {
         case TorrentData::UpdateKey::UploadSpeedLimit:
             return setChanged(uploadSpeedLimit, value.toInt(), changed);
         case TorrentData::UpdateKey::TotalDownloaded:
-            return setChanged(totalDownloaded, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(totalDownloaded, toInt64(value), changed);
         case TorrentData::UpdateKey::TotalUploaded:
-            return setChanged(totalUploaded, static_cast<long long>(value.toDouble()), changed);
+            return setChanged(totalUploaded, toInt64(value), changed);
         case TorrentData::UpdateKey::Ratio:
             return setChanged(ratio, value.toDouble(), changed);
         case TorrentData::UpdateKey::RatioLimitMode:

--- a/torrent.h
+++ b/torrent.h
@@ -66,10 +66,10 @@ namespace libtremotesf {
 
         int queuePosition{};
 
-        long long totalSize{};
-        long long completedSize{};
-        long long leftUntilDone{};
-        long long sizeWhenDone{};
+        qint64 totalSize{};
+        qint64 completedSize{};
+        qint64 leftUntilDone{};
+        qint64 sizeWhenDone{};
 
         double percentDone{};
         double recheckProgress{};
@@ -77,16 +77,16 @@ namespace libtremotesf {
 
         bool metadataComplete{};
 
-        long long downloadSpeed{};
-        long long uploadSpeed{};
+        qint64 downloadSpeed{};
+        qint64 uploadSpeed{};
 
         bool downloadSpeedLimited{};
         int downloadSpeedLimit{}; // kB/s
         bool uploadSpeedLimited{};
         int uploadSpeedLimit{}; // kB/s
 
-        long long totalDownloaded{};
-        long long totalUploaded{};
+        qint64 totalDownloaded{};
+        qint64 totalUploaded{};
         double ratio{};
         double ratioLimit{};
         RatioLimitMode ratioLimitMode{};

--- a/torrentfile.cpp
+++ b/torrentfile.cpp
@@ -21,7 +21,7 @@ namespace libtremotesf {
     }
 
     TorrentFile::TorrentFile(int id, const QJsonObject& fileMap, const QJsonObject& fileStatsMap)
-        : id(id), size(static_cast<long long>(fileMap.value("length"_l1).toDouble())) {
+        : id(id), size(toInt64(fileMap.value("length"_l1))) {
         auto p = fileMap.value("name"_l1).toString().split(QLatin1Char('/'), Qt::SkipEmptyParts);
         path.reserve(static_cast<size_t>(p.size()));
         for (QString& part : p) {
@@ -33,7 +33,7 @@ namespace libtremotesf {
     bool TorrentFile::update(const QJsonObject& fileStatsMap) {
         bool changed = false;
 
-        setChanged(completedSize, static_cast<long long>(fileStatsMap.value("bytesCompleted"_l1).toDouble()), changed);
+        setChanged(completedSize, toInt64(fileStatsMap.value("bytesCompleted"_l1)), changed);
         constexpr auto priorityKey = "priority"_l1;
         setChanged(priority, priorityMapper.fromJsonValue(fileStatsMap.value(priorityKey), priorityKey), changed);
         setChanged(wanted, fileStatsMap.value("wanted"_l1).toBool(), changed);

--- a/torrentfile.h
+++ b/torrentfile.h
@@ -26,8 +26,8 @@ namespace libtremotesf {
         int id{};
 
         std::vector<QString> path{};
-        long long size{};
-        long long completedSize{};
+        qint64 size{};
+        qint64 completedSize{};
         Priority priority{};
         bool wanted{};
     };


### PR DESCRIPTION
We are using it instead of int64_t because is plays nicer with QVariant. Also add helper to use QJsonValue::toInteger with Qt 6.