### PR TITLE
Fix for Qt 6.5.0

### DIFF
--- a/requestrouter.cpp
+++ b/requestrouter.cpp
@@ -26,9 +26,6 @@ SPECIALIZE_FORMATTER_FOR_QDEBUG(QJsonObject)
 SPECIALIZE_FORMATTER_FOR_QDEBUG(QNetworkProxy)
 SPECIALIZE_FORMATTER_FOR_QDEBUG(QSslError)
 
-Q_DECLARE_METATYPE(libtremotesf::impl::RpcRequestMetadata)
-Q_DECLARE_METATYPE(libtremotesf::impl::NetworkRequestMetadata)
-
 namespace fmt {
     template<>
     struct formatter<QSsl::SslProtocol> : libtremotesf::SimpleFormatter {
@@ -429,3 +426,6 @@ namespace libtremotesf::impl {
         return detailedErrorMessage;
     }
 }
+
+Q_DECLARE_METATYPE(libtremotesf::impl::RpcRequestMetadata)
+Q_DECLARE_METATYPE(libtremotesf::impl::NetworkRequestMetadata)


### PR DESCRIPTION
Qt 6.5.0 requires Q_DECLARE_METATYPE to be used after type is defined.