### PR TITLE
Always send `Authorization` header when authentication is requested (fixes #169)

### DIFF
--- a/requestrouter.cpp
+++ b/requestrouter.cpp
@@ -88,6 +88,7 @@ namespace fmt {
 namespace libtremotesf::impl {
     namespace {
         const auto sessionIdHeader = QByteArrayLiteral("X-Transmission-Session-Id");
+        const auto authorizationHeader = QByteArrayLiteral("Authorization");
 
         constexpr auto metadataProperty = "libtremotesf::impl::RequestRouter metadata";
 
@@ -157,7 +158,11 @@ namespace libtremotesf::impl {
             logDebug(" - Timeout: {}", mConfiguration.timeout);
             logDebug(" - HTTP Basic access authentication: {}", mConfiguration.authentication);
             if (mConfiguration.authentication) {
-                auto base64Credentials = QString("%1:%2").arg(mConfiguration.username, mConfiguration.password).toUtf8().toBase64();
+                auto base64Credentials = QString("%1:%2")
+                                             .arg(mConfiguration.username, mConfiguration.password)
+                                             .normalized(QString::NormalizationForm_C)
+                                             .toUtf8()
+                                             .toBase64();
                 mBasicAuthHeaderValue = QByteArray("Basic ").append(base64Credentials);
             }
             if (https) {
@@ -237,7 +242,7 @@ namespace libtremotesf::impl {
             request.setRawHeader(sessionIdHeader, mSessionId);
         }
         if (mConfiguration.authentication) {
-            request.setRawHeader(QByteArray("Authorization"), QByteArray(mBasicAuthHeaderValue));
+            request.setRawHeader(authorizationHeader, QByteArray(mBasicAuthHeaderValue));
         }
         QNetworkReply* reply = mNetwork->post(request, metadata.postData);
         reply->setProperty(metadataProperty, QVariant::fromValue(metadata));

--- a/requestrouter.cpp
+++ b/requestrouter.cpp
@@ -163,7 +163,7 @@ namespace libtremotesf::impl {
                                              .normalized(QString::NormalizationForm_C)
                                              .toUtf8()
                                              .toBase64();
-                mBasicAuthHeaderValue = QByteArray("Basic ").append(base64Credentials);
+                mAuthorizationHeaderValue = QByteArray("Basic ").append(base64Credentials);
             }
             if (https) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
@@ -242,7 +242,7 @@ namespace libtremotesf::impl {
             request.setRawHeader(sessionIdHeader, mSessionId);
         }
         if (mConfiguration.authentication) {
-            request.setRawHeader(authorizationHeader, mBasicAuthHeaderValue);
+            request.setRawHeader(authorizationHeader, mAuthorizationHeaderValue);
         }
         QNetworkReply* reply = mNetwork->post(request, metadata.postData);
         reply->setProperty(metadataProperty, QVariant::fromValue(metadata));

--- a/requestrouter.cpp
+++ b/requestrouter.cpp
@@ -242,7 +242,7 @@ namespace libtremotesf::impl {
             request.setRawHeader(sessionIdHeader, mSessionId);
         }
         if (mConfiguration.authentication) {
-            request.setRawHeader(authorizationHeader, QByteArray(mBasicAuthHeaderValue));
+            request.setRawHeader(authorizationHeader, mBasicAuthHeaderValue);
         }
         QNetworkReply* reply = mNetwork->post(request, metadata.postData);
         reply->setProperty(metadataProperty, QVariant::fromValue(metadata));

--- a/requestrouter.h
+++ b/requestrouter.h
@@ -87,7 +87,6 @@ namespace libtremotesf::impl {
 
         bool retryRequest(const QNetworkRequest& request, NetworkRequestMetadata&& metadata);
 
-        void onAuthenticationRequired(QNetworkReply*, QAuthenticator* authenticator) const;
         void onRequestFinished(QNetworkReply* reply, QList<QSslError>&& sslErrors);
         void onRequestSuccess(QNetworkReply* reply, RpcRequestMetadata&& metadata);
         void onRequestError(QNetworkReply* reply, QList<QSslError>&& sslErrors, NetworkRequestMetadata&& metadata);
@@ -98,6 +97,7 @@ namespace libtremotesf::impl {
         std::unordered_set<QNetworkReply*> mPendingNetworkRequests{};
         std::unordered_set<QObject*> mPendingParseFutures{};
         QByteArray mSessionId{};
+        QByteArray mBasicAuthHeaderValue{};
 
         RequestsConfiguration mConfiguration{};
         QSslConfiguration mSslConfiguration{};

--- a/requestrouter.h
+++ b/requestrouter.h
@@ -97,7 +97,7 @@ namespace libtremotesf::impl {
         std::unordered_set<QNetworkReply*> mPendingNetworkRequests{};
         std::unordered_set<QObject*> mPendingParseFutures{};
         QByteArray mSessionId{};
-        QByteArray mBasicAuthHeaderValue{};
+        QByteArray mAuthorizationHeaderValue{};
 
         RequestsConfiguration mConfiguration{};
         QSslConfiguration mSslConfiguration{};


### PR DESCRIPTION
See #169: I have a setup where I let a proxy do authentication, and it doesn't respond with a `401` status and `WWW-Authenticate` header, as it usually redirects to a login page, but it *does* process the `Authorization` header when it's in the request. This PR makes it possible to use such a setup.

Tiny bonus: the first request to pass through the `QNetworkAccessManager` won't have to be performed twice, since authentication happens immediately.